### PR TITLE
fixing total second update problem when add

### DIFF
--- a/pomodoro-clock/pomodoro-app/src/components/Pomodoro.vue
+++ b/pomodoro-clock/pomodoro-app/src/components/Pomodoro.vue
@@ -125,6 +125,7 @@ export default {
       this.timers = this.timers.map((timer, i) => {
         return { ...timer, minutes: parseInt(updatedTimers[i]) }
       })
+	  this.totalSeconds = this.timers[this.currentTimer].minutes * 60;
       this.closeDialog()
     }
   }


### PR DESCRIPTION
This will fix the issue of the total second update on the same screen when total time is added by the user.